### PR TITLE
Added support for en_gb and fr_fr locales

### DIFF
--- a/src/Date/Extra/Config/Config_en_gb.elm
+++ b/src/Date/Extra/Config/Config_en_gb.elm
@@ -1,0 +1,32 @@
+module Date.Extra.Config.Config_en_gb exposing (..)
+
+{-| This is the UK english config for formatting dates.
+
+@docs config
+
+Copyright (c) 2016 Bruno Girin
+-}
+
+import Date
+import Date.Extra.Config as Config
+import Date.Extra.I18n.I_en_us as English
+
+
+{-| Config for en-gb. -}
+config : Config.Config
+config =
+  { i18n =
+      { dayShort = English.dayShort
+      , dayName = English.dayName
+      , monthShort = English.monthShort
+      , monthName = English.monthName
+      }
+  , format =
+      { date = "%-d/%m/%Y" -- d/MM/yyyy
+      , longDate = "%A, %-d %B %Y" -- dddd, d MMMM yyyy
+      , time = "%-I:%M %p" -- h:mm tt
+      , longTime = "%-I:%M:%S %p" -- h:mm:ss tt
+      , dateTime = "%-d/%m/%Y %-I:%M %p"  -- date + time
+      , firstDayOfWeek = Date.Mon
+      }
+  }

--- a/src/Date/Extra/Config/Config_en_us.elm
+++ b/src/Date/Extra/Config/Config_en_us.elm
@@ -27,6 +27,6 @@ config =
       , time = "%-H:%M %p" -- h:mm tt
       , longTime = "%-H:%M:%S %p" -- h:mm:ss tt
       , dateTime = "%-m/%-d/%Y %-I:%M %p" -- date + time
-      , firstDayOfWeek = Date.Mon
+      , firstDayOfWeek = Date.Sun
       }
   }

--- a/src/Date/Extra/Config/Config_fr_fr.elm
+++ b/src/Date/Extra/Config/Config_fr_fr.elm
@@ -1,0 +1,32 @@
+module Date.Extra.Config.Config_fr_fr exposing (..)
+
+{-| This is the French config for formatting dates.
+
+@docs config
+
+Copyright (c) 2016 Bruno Girin
+-}
+
+import Date
+import Date.Extra.Config as Config
+import Date.Extra.I18n.I_fr_fr as French
+
+
+{-| Config for fr-fr. -}
+config : Config.Config
+config =
+  { i18n =
+      { dayShort = French.dayShort
+      , dayName = French.dayName
+      , monthShort = French.monthShort
+      , monthName = French.monthName
+      }
+  , format =
+      { date = "%-d/%m/%Y" -- d/MM/yyyy
+      , longDate = "%A, %-d %B %Y" -- dddd, d MMMM yyyy
+      , time = "%-I:%M %p" -- h:mm tt
+      , longTime = "%-I:%M:%S %p" -- h:mm:ss tt
+      , dateTime = "%-d/%m/%Y %-I:%M %p"  -- date + time
+      , firstDayOfWeek = Date.Mon
+      }
+  }

--- a/src/Date/Extra/Config/Configs.elm
+++ b/src/Date/Extra/Config/Configs.elm
@@ -18,6 +18,8 @@ import String
 import Date.Extra.Config as Config exposing (Config)
 import Date.Extra.Config.Config_en_us as Config_en_us
 import Date.Extra.Config.Config_en_au as Config_en_au
+import Date.Extra.Config.Config_en_gb as Config_en_gb
+import Date.Extra.Config.Config_fr_fr as Config_fr_fr
 
 
 {-| Built in configurations. -}
@@ -26,6 +28,8 @@ configs =
   Dict.fromList
     [ ("en_au", Config_en_au.config)
     , ("en_us", Config_en_us.config)
+    , ("en_gb", Config_en_gb.config)
+    , ("fr_fr", Config_fr_fr.config)
     ]
 
 

--- a/src/Date/Extra/I18n/I_fr_fr.elm
+++ b/src/Date/Extra/I18n/I_fr_fr.elm
@@ -1,0 +1,76 @@
+module Date.Extra.I18n.I_fr_fr exposing (..)
+
+{-| French values for day and month names.
+
+@docs dayShort
+@docs dayName
+@docs monthShort
+@docs monthName
+
+Copyright (c) 2016 Bruno Girin
+-}
+
+
+import Date exposing (Day (..), Month (..))
+
+
+{-| Day short name. -}
+dayShort : Day -> String
+dayShort day =
+  case day of
+    Mon -> "lun"
+    Tue -> "mar"
+    Wed -> "mer"
+    Thu -> "jeu"
+    Fri -> "ven"
+    Sat -> "sam"
+    Sun -> "dim"
+
+
+{-| Day full name. -}
+dayName : Day -> String
+dayName day =
+  case day of
+    Mon -> "lundi"
+    Tue -> "mardi"
+    Wed -> "mercredi"
+    Thu -> "jeudi"
+    Fri -> "vendredi"
+    Sat -> "samedi"
+    Sun -> "dimanche"
+
+
+{-| Month short name. -}
+monthShort : Month -> String
+monthShort month =
+  case month of
+    Jan -> "jan"
+    Feb -> "fév"
+    Mar -> "mar"
+    Apr -> "avr"
+    May -> "mai"
+    Jun -> "jun"
+    Jul -> "jul"
+    Aug -> "aou"
+    Sep -> "sep"
+    Oct -> "oct"
+    Nov -> "nov"
+    Dec -> "déc"
+
+
+{-| Month full name. -}
+monthName : Month -> String
+monthName month =
+  case month of
+    Jan -> "janvier"
+    Feb -> "février"
+    Mar -> "mars"
+    Apr -> "avril"
+    May -> "mai"
+    Jun -> "juin"
+    Jul -> "juillet"
+    Aug -> "août"
+    Sep -> "septembre"
+    Oct -> "octobre"
+    Nov -> "novembre"
+    Dec -> "décembre"

--- a/tests/Date/Extra/ConfigTests.elm
+++ b/tests/Date/Extra/ConfigTests.elm
@@ -5,11 +5,15 @@ import ElmTest exposing (..)
 
 import Date.Extra.Config.Config_en_au as Config_en_au
 import Date.Extra.Config.Config_en_us as Config_en_us
+import Date.Extra.Config.Config_fr_fr as Config_en_gb
+import Date.Extra.Config.Config_fr_fr as Config_fr_fr
 import Date.Extra.Config.Configs as Configs
 
 
 config_en_au = Config_en_au.config
 config_en_us = Config_en_us.config
+config_en_gb = Config_en_gb.config
+config_fr_fr = Config_fr_fr.config
 
 
 tests : Test
@@ -31,4 +35,12 @@ tests =
         assertEqual
           config_en_us.format
           (Configs.getConfig "anything").format
+    , test "getConfig en_gb" <|
+        assertEqual
+          config_en_gb.format
+          (Configs.getConfig "en_gb").format
+    , test "getConfig fr_fr" <|
+        assertEqual
+          config_fr_fr.format
+          (Configs.getConfig "fr_fr").format
     ]

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "$0")"
+set -e
+
+elm-make --yes --output program.js TestRunner.elm
+node program.js


### PR DESCRIPTION
Added `en_gb` and `fr_fr` locales with basic config tests for those. Note for French that neither the names of days of the week or months are capitalised and that some names have non-ASCII characters so the assumption is that files will be treated as UTF-8 by editors.

While I was at it, I also added a *nix shell script to run the tests and made a small modification to the `en_us` locale as the first day of the week in the US is Sunday.