### PR TITLE
Add Romanian translations

### DIFF
--- a/src/Date/Extra/Config/Config_ro_ro.elm
+++ b/src/Date/Extra/Config/Config_ro_ro.elm
@@ -1,0 +1,33 @@
+module Date.Extra.Config.Config_ro_ro exposing (..)
+
+{-| This is the Romanian config for formatting dates.
+
+@docs config
+
+Copyright (c) 2016 Cezar Halmagean
+-}
+
+import Date
+import Date.Extra.Config as Config
+import Date.Extra.I18n.I_ro_ro as Romanian
+
+
+{-| Config for ro_ro. -}
+config : Config.Config
+config =
+  { i18n =
+      { dayShort = Romanian.dayShort
+      , dayName = Romanian.dayName
+      , monthShort = Romanian.monthShort
+      , monthName = Romanian.monthName
+      , dayOfMonthWithSuffix = Romanian.dayOfMonthWithSuffix
+      }
+  , format =
+      { date = "%d.%m.%Y" -- dd.MM.yyyy
+      , longDate = "%A, %-d %B %Y" -- dddd, d MMMM yyyy
+      , time = "%-H:%M" -- h:mm
+      , longTime = "%-H:%M:%S" -- h:mm:ss
+      , dateTime = "%-d.%m.%Y %-H:%M"  -- date + time
+      , firstDayOfWeek = Date.Mon
+      }
+  }

--- a/src/Date/Extra/I18n/I_ro_ro.elm
+++ b/src/Date/Extra/I18n/I_ro_ro.elm
@@ -1,0 +1,84 @@
+module Date.Extra.I18n.I_ro_ro exposing (..)
+
+{-| Romanian values for day and month names.
+
+@docs dayShort
+@docs dayName
+@docs monthShort
+@docs monthName
+@docs dayOfMonthWithSuffix
+
+Copyright (c) 2016 Cezar Halmagean
+-}
+
+
+import Date exposing (Day (..), Month (..))
+
+
+{-| Day short name. -}
+dayShort : Day -> String
+dayShort day =
+  case day of
+    Mon -> "Lun"
+    Tue -> "Mar"
+    Wed -> "Mie"
+    Thu -> "Joi"
+    Fri -> "Vin"
+    Sat -> "Sâm"
+    Sun -> "Dum"
+
+
+{-| Day full name. -}
+dayName : Day -> String
+dayName day =
+  case day of
+    Mon -> "Luni"
+    Tue -> "Marți"
+    Wed -> "Miercuri"
+    Thu -> "Joi"
+    Fri -> "Vineri"
+    Sat -> "Sâmbătă"
+    Sun -> "Duminică"
+
+
+{-| Month short name. -}
+monthShort : Month -> String
+monthShort month =
+  case month of
+    Jan -> "Ian"
+    Feb -> "Feb"
+    Mar -> "Mar"
+    Apr -> "Apr"
+    May -> "Mai"
+    Jun -> "Iun"
+    Jul -> "Iul"
+    Aug -> "Aug"
+    Sep -> "Sep"
+    Oct -> "Oct"
+    Nov -> "Noi"
+    Dec -> "Dec"
+
+
+{-| Month full name. -}
+monthName : Month -> String
+monthName month =
+  case month of
+    Jan -> "Ianuarie"
+    Feb -> "Februarie"
+    Mar -> "Martie"
+    Apr -> "Aprilie"
+    May -> "Mai"
+    Jun -> "Iunie"
+    Jul -> "Iulie"
+    Aug -> "August"
+    Sep -> "Septembrie"
+    Oct -> "Octombrie"
+    Nov -> "Noiembrie"
+    Dec -> "Decembrie"
+
+
+{-| No suffixes for Romanian -}
+dayOfMonthWithSuffix : Bool -> Int -> String
+dayOfMonthWithSuffix pad day =
+  case day of
+    _ -> (toString day)


### PR DESCRIPTION
This adds support for the Romanian language. It adds the `Config_ro_ro` and `I_ro_ro ` modules. 