### PR TITLE
Add support for Greek and translatable 12-hour clock abbreviations

### DIFF
--- a/src/Date/Extra/Config.elm
+++ b/src/Date/Extra/Config.elm
@@ -14,6 +14,7 @@ Copyright (c) 2016-2017 Robin Luiten
 -}
 
 import Date exposing (Day, Month)
+import Date.Extra.TwelveHourClock exposing (TwelveHourPeriod)
 
 
 {-| Configuration for formatting dates.
@@ -25,6 +26,7 @@ type alias Config =
         , monthShort : Month -> String
         , monthName : Month -> String
         , dayOfMonthWithSuffix : Bool -> Int -> String
+        , twelveHourPeriod : TwelveHourPeriod -> String
         }
     , format :
         { date : String

--- a/src/Date/Extra/Config/Config_de_de.elm
+++ b/src/Date/Extra/Config/Config_de_de.elm
@@ -11,6 +11,7 @@ Copyright (c) 2017 Frank Schmitt
 import Date
 import Date.Extra.Config as Config
 import Date.Extra.I18n.I_de_de as German
+import Date.Extra.I18n.I_default as Default
 
 
 {-| Config for en-us.
@@ -23,28 +24,24 @@ config =
         , monthShort = German.monthShort
         , monthName = German.monthName
         , dayOfMonthWithSuffix = German.dayOfMonthWithSuffix
+        , twelveHourPeriod = Default.twelveHourPeriod
         }
     , format =
         { date =
             "%-d. %B %Y"
-
-        -- d. M YYYY. a
+            -- d. M YYYY. a
         , longDate =
             "%A, %-d. %B %Y"
-
-        -- dddd, dd. MMMM yyyy
+            -- dddd, dd. MMMM yyyy
         , time =
             "%-H:%M"
-
-        -- h:mm
+            -- h:mm
         , longTime =
             "%-H:%M:%S"
-
-        -- h:mm:ss
+            -- h:mm:ss
         , dateTime =
             "%a, %-d. %b %Y. %-H:%M:%S"
-
-        -- date + time
+            -- date + time
         , firstDayOfWeek = Date.Mon
         }
     }

--- a/src/Date/Extra/Config/Config_el_gr.elm
+++ b/src/Date/Extra/Config/Config_el_gr.elm
@@ -1,0 +1,52 @@
+module Date.Extra.Config.Config_el_gr exposing (..)
+
+{-| This is the Greek (Greece) config for formatting dates.
+
+@docs config
+
+Copyright (c) 2017 Eleni Lixourioti
+
+-}
+
+import Date
+import Date.Extra.Config as Config
+import Date.Extra.I18n.I_el_gr as Greek
+
+
+{-| Config for en-gb.
+-}
+config : Config.Config
+config =
+    { i18n =
+        { dayShort = Greek.dayShort
+        , dayName = Greek.dayName
+        , monthShort = Greek.monthShort
+        , monthName = Greek.monthName
+        , dayOfMonthWithSuffix = Greek.dayOfMonthWithSuffix
+        , twelveHourPeriod = Greek.twelveHourPeriod
+        }
+    , format =
+        -- TODO: Verify those types:
+        { date =
+            "%-d/%-m/%y"
+            -- d/M/yyyy
+        , longDate =
+            "%A, %-d %B %Y"
+            -- EEEE, d MMMM yyyy
+            -- ex. "Παρασκευή, 9 Ιουνίου 2017"
+            -- TODO:
+            -- Τhe month suffix is correct in this case, but could be wrong
+            -- in other contexts. When rendering the month on its own
+            -- (e.g. "%B") then it should be "Ιούνιος" rather than "Ιουνίου"
+        , time =
+            "%-I:%M %P"
+            -- h:mm tt
+        , longTime =
+            "%-I:%M:%S %P"
+            -- h:mm:ss a
+        , dateTime =
+            "-d/%m/%Y %-I:%M %P"
+            -- date + time
+        , firstDayOfWeek = Date.Sun
+        }
+    }

--- a/src/Date/Extra/Config/Config_el_gr.elm
+++ b/src/Date/Extra/Config/Config_el_gr.elm
@@ -4,8 +4,6 @@ module Date.Extra.Config.Config_el_gr exposing (..)
 
 @docs config
 
-Copyright (c) 2017 Eleni Lixourioti
-
 -}
 
 import Date
@@ -13,7 +11,7 @@ import Date.Extra.Config as Config
 import Date.Extra.I18n.I_el_gr as Greek
 
 
-{-| Config for en-gb.
+{-| Config for el-gr.
 -}
 config : Config.Config
 config =
@@ -29,7 +27,7 @@ config =
         -- TODO: Verify those types:
         { date =
             "%-d/%-m/%y"
-            -- d/M/yyyy
+            -- d/M/yy
         , longDate =
             "%A, %-d %B %Y"
             -- EEEE, d MMMM yyyy

--- a/src/Date/Extra/Config/Config_en_au.elm
+++ b/src/Date/Extra/Config/Config_en_au.elm
@@ -11,6 +11,7 @@ Copyright (c) 2016-2017 Robin Luiten
 import Date
 import Date.Extra.Config as Config
 import Date.Extra.I18n.I_en_us as English
+import Date.Extra.I18n.I_default as Default
 
 
 {-| Config for en-au.
@@ -23,13 +24,24 @@ config =
         , monthShort = English.monthShort
         , monthName = English.monthName
         , dayOfMonthWithSuffix = English.dayOfMonthWithSuffix
+        , twelveHourPeriod = Default.twelveHourPeriod
         }
     , format =
-        { date = "%-d/%m/%Y" -- d/MM/yyyy
-        , longDate = "%A, %-d %B %Y" -- dddd, d MMMM yyyy
-        , time = "%-I:%M %p" -- h:mm tt
-        , longTime = "%-I:%M:%S %p" -- h:mm:ss tt
-        , dateTime = "%-d/%m/%Y %-I:%M %p" -- date + time
+        { date =
+            "%-d/%m/%Y"
+            -- d/MM/yyyy
+        , longDate =
+            "%A, %-d %B %Y"
+            -- dddd, d MMMM yyyy
+        , time =
+            "%-I:%M %p"
+            -- h:mm tt
+        , longTime =
+            "%-I:%M:%S %p"
+            -- h:mm:ss tt
+        , dateTime =
+            "%-d/%m/%Y %-I:%M %p"
+            -- date + time
         , firstDayOfWeek = Date.Mon
         }
     }

--- a/src/Date/Extra/Config/Config_en_gb.elm
+++ b/src/Date/Extra/Config/Config_en_gb.elm
@@ -11,6 +11,7 @@ Copyright (c) 2016-2017 Bruno Girin
 import Date
 import Date.Extra.Config as Config
 import Date.Extra.I18n.I_en_us as English
+import Date.Extra.I18n.I_default as Default
 
 
 {-| Config for en-gb.
@@ -23,13 +24,24 @@ config =
         , monthShort = English.monthShort
         , monthName = English.monthName
         , dayOfMonthWithSuffix = English.dayOfMonthWithSuffix
+        , twelveHourPeriod = Default.twelveHourPeriod
         }
     , format =
-        { date = "%-d/%m/%Y" -- d/MM/yyyy
-        , longDate = "%A, %-d %B %Y" -- dddd, d MMMM yyyy
-        , time = "%-I:%M %p" -- h:mm tt
-        , longTime = "%-I:%M:%S %p" -- h:mm:ss tt
-        , dateTime = "%-d/%m/%Y %-I:%M %p" -- date + time
+        { date =
+            "%-d/%m/%Y"
+            -- d/MM/yyyy
+        , longDate =
+            "%A, %-d %B %Y"
+            -- dddd, d MMMM yyyy
+        , time =
+            "%-I:%M %p"
+            -- h:mm tt
+        , longTime =
+            "%-I:%M:%S %p"
+            -- h:mm:ss tt
+        , dateTime =
+            "%-d/%m/%Y %-I:%M %p"
+            -- date + time
         , firstDayOfWeek = Date.Mon
         }
     }

--- a/src/Date/Extra/Config/Config_en_us.elm
+++ b/src/Date/Extra/Config/Config_en_us.elm
@@ -11,6 +11,7 @@ Copyright (c) 2016-2017 Robin Luiten
 import Date
 import Date.Extra.Config as Config
 import Date.Extra.I18n.I_en_us as English
+import Date.Extra.I18n.I_default as Default
 
 
 {-| Config for en-us.
@@ -23,13 +24,24 @@ config =
         , monthShort = English.monthShort
         , monthName = English.monthName
         , dayOfMonthWithSuffix = English.dayOfMonthWithSuffix
+        , twelveHourPeriod = Default.twelveHourPeriod
         }
     , format =
-        { date = "%-m/%-d/%Y" -- M/d/YYY
-        , longDate = "%A, %B %d, %Y" -- dddd, MMMM dd, yyyy
-        , time = "%-H:%M %p" -- h:mm tt
-        , longTime = "%-H:%M:%S %p" -- h:mm:ss tt
-        , dateTime = "%-m/%-d/%Y %-I:%M %p" -- date + time
+        { date =
+            "%-m/%-d/%Y"
+            -- M/d/YYY
+        , longDate =
+            "%A, %B %d, %Y"
+            -- dddd, MMMM dd, yyyy
+        , time =
+            "%-H:%M %p"
+            -- h:mm tt
+        , longTime =
+            "%-H:%M:%S %p"
+            -- h:mm:ss tt
+        , dateTime =
+            "%-m/%-d/%Y %-I:%M %p"
+            -- date + time
         , firstDayOfWeek = Date.Sun
         }
     }

--- a/src/Date/Extra/Config/Config_et_ee.elm
+++ b/src/Date/Extra/Config/Config_et_ee.elm
@@ -11,6 +11,7 @@ Copyright (c) 2016-2017 Robin Luiten
 import Date
 import Date.Extra.Config as Config
 import Date.Extra.I18n.I_et_ee as Estonian
+import Date.Extra.I18n.I_default as Default
 
 
 {-| Config for en-us.
@@ -23,28 +24,24 @@ config =
         , monthShort = Estonian.monthShort
         , monthName = Estonian.monthName
         , dayOfMonthWithSuffix = Estonian.dayOfMonthWithSuffix
+        , twelveHourPeriod = Default.twelveHourPeriod
         }
     , format =
         { date =
             "%-d. %b %Y. a"
-
-        -- d. M YYYY. a
+            -- d. M YYYY. a
         , longDate =
             "%A, %-d. %B %Y"
-
-        -- dddd, dd. MMMM yyyy
+            -- dddd, dd. MMMM yyyy
         , time =
             "%-H:%M"
-
-        -- h:mm
+            -- h:mm
         , longTime =
             "%-H:%M:%S"
-
-        -- h:mm:ss
+            -- h:mm:ss
         , dateTime =
             "%a, %-d. %b %Y. %-H:%M:%S"
-
-        -- date + time
+            -- date + time
         , firstDayOfWeek = Date.Mon
         }
     }

--- a/src/Date/Extra/Config/Config_fi_fi.elm
+++ b/src/Date/Extra/Config/Config_fi_fi.elm
@@ -11,6 +11,7 @@ Copyright (c) 2016-2017 Ossi Hanhinen
 import Date
 import Date.Extra.Config as Config
 import Date.Extra.I18n.I_fi_fi as Finnish
+import Date.Extra.I18n.I_default as Default
 
 
 {-| Config for fi-fi.
@@ -23,13 +24,24 @@ config =
         , monthShort = Finnish.monthShort
         , monthName = Finnish.monthName
         , dayOfMonthWithSuffix = Finnish.dayOfMonthWithSuffix
+        , twelveHourPeriod = Default.twelveHourPeriod
         }
     , format =
-        { date = "%-d.%-m.%Y" -- d.m.YYYY
-        , longDate = "%A, %-d %B %Y" -- dddd, d MMMM yyyy
-        , time = "%-H:%M" -- h:mm
-        , longTime = "%-H:%M:%S" -- h:mm:ss
-        , dateTime = "%-d.%-m.%Y %-H:%M" -- date + time
+        { date =
+            "%-d.%-m.%Y"
+            -- d.m.YYYY
+        , longDate =
+            "%A, %-d %B %Y"
+            -- dddd, d MMMM yyyy
+        , time =
+            "%-H:%M"
+            -- h:mm
+        , longTime =
+            "%-H:%M:%S"
+            -- h:mm:ss
+        , dateTime =
+            "%-d.%-m.%Y %-H:%M"
+            -- date + time
         , firstDayOfWeek = Date.Mon
         }
     }

--- a/src/Date/Extra/Config/Config_fr_fr.elm
+++ b/src/Date/Extra/Config/Config_fr_fr.elm
@@ -11,6 +11,7 @@ Copyright (c) 2016-2017 Bruno Girin
 import Date
 import Date.Extra.Config as Config
 import Date.Extra.I18n.I_fr_fr as French
+import Date.Extra.I18n.I_default as Default
 
 
 {-| Config for fr-fr.
@@ -23,13 +24,24 @@ config =
         , monthShort = French.monthShort
         , monthName = French.monthName
         , dayOfMonthWithSuffix = French.dayOfMonthWithSuffix
+        , twelveHourPeriod = Default.twelveHourPeriod
         }
     , format =
-        { date = "%-d/%m/%Y" -- d/MM/yyyy
-        , longDate = "%A, %-d %B %Y" -- dddd, d MMMM yyyy
-        , time = "%-I:%M %p" -- h:mm tt
-        , longTime = "%-I:%M:%S %p" -- h:mm:ss tt
-        , dateTime = "%-d/%m/%Y %-I:%M %p" -- date + time
+        { date =
+            "%-d/%m/%Y"
+            -- d/MM/yyyy
+        , longDate =
+            "%A, %-d %B %Y"
+            -- dddd, d MMMM yyyy
+        , time =
+            "%-I:%M %p"
+            -- h:mm tt
+        , longTime =
+            "%-I:%M:%S %p"
+            -- h:mm:ss tt
+        , dateTime =
+            "%-d/%m/%Y %-I:%M %p"
+            -- date + time
         , firstDayOfWeek = Date.Mon
         }
     }

--- a/src/Date/Extra/Config/Config_ja_jp.elm
+++ b/src/Date/Extra/Config/Config_ja_jp.elm
@@ -11,6 +11,7 @@ Copyright (c) 2017 Yosuke Torii
 import Date
 import Date.Extra.Config as Config
 import Date.Extra.I18n.I_ja_jp as Japanese
+import Date.Extra.I18n.I_default as Default
 
 
 {-| Config for ja_jp.
@@ -23,6 +24,7 @@ config =
         , monthShort = Japanese.monthShort
         , monthName = Japanese.monthName
         , dayOfMonthWithSuffix = Japanese.dayOfMonthWithSuffix
+        , twelveHourPeriod = Default.twelveHourPeriod
         }
     , format =
         { date = "%Y/%-m/%-d"

--- a/src/Date/Extra/Config/Config_lt_lt.elm
+++ b/src/Date/Extra/Config/Config_lt_lt.elm
@@ -11,6 +11,7 @@ Copyright (c) 2016-2017 Robin Luiten
 import Date
 import Date.Extra.Config as Config
 import Date.Extra.I18n.I_lt_lt as Lithuanian
+import Date.Extra.I18n.I_default as Default
 
 
 {-| Config for en-us.
@@ -23,6 +24,7 @@ config =
         , monthShort = Lithuanian.monthShort
         , monthName = Lithuanian.monthName
         , dayOfMonthWithSuffix = Lithuanian.dayOfMonthWithSuffix
+        , twelveHourPeriod = Default.twelveHourPeriod
         }
     , format =
         { date =

--- a/src/Date/Extra/Config/Config_nl_nl.elm
+++ b/src/Date/Extra/Config/Config_nl_nl.elm
@@ -11,6 +11,7 @@ Copyright (c) 2016-2017 Mats Stijlaart
 import Date
 import Date.Extra.Config as Config
 import Date.Extra.I18n.I_nl_nl as Dutch
+import Date.Extra.I18n.I_default as Default
 
 
 {-| Config for nl-nl.
@@ -23,28 +24,24 @@ config =
         , monthShort = Dutch.monthShort
         , monthName = Dutch.monthName
         , dayOfMonthWithSuffix = Dutch.dayOfMonthWithSuffix
+        , twelveHourPeriod = Default.twelveHourPeriod
         }
     , format =
         { date =
             "%d-%m-%Y"
-
-        -- dd-mm-yyy
+            -- dd-mm-yyy
         , longDate =
             "%A, %B %d, %Y"
-
-        -- dddd, MMMM dd, yyyy
+            -- dddd, MMMM dd, yyyy
         , time =
             "%H:%M"
-
-        -- hh:mm
+            -- hh:mm
         , longTime =
             "%-H:%M:%S %p"
-
-        -- h:mm:ss tt
+            -- h:mm:ss tt
         , dateTime =
             "%d-%m-%Y %H:%M"
-
-        -- date time
+            -- date time
         , firstDayOfWeek = Date.Mon
         }
     }

--- a/src/Date/Extra/Config/Config_pl_pl.elm
+++ b/src/Date/Extra/Config/Config_pl_pl.elm
@@ -11,6 +11,7 @@ Copyright (c) 2016-2017 Bartosz Sokół
 import Date
 import Date.Extra.Config as Config
 import Date.Extra.I18n.I_pl_pl as Polish
+import Date.Extra.I18n.I_default as Default
 
 
 {-| Config for pl-pl.
@@ -23,13 +24,24 @@ config =
         , monthShort = Polish.monthShort
         , monthName = Polish.monthName
         , dayOfMonthWithSuffix = Polish.dayOfMonthWithSuffix
+        , twelveHourPeriod = Default.twelveHourPeriod
         }
     , format =
-        { date = "%d.%m.%Y" -- dd.MM.yyyy
-        , longDate = "%A, %-d %B %Y" -- dddd, d MMMM yyyy
-        , time = "%-H:%M" -- h:mm
-        , longTime = "%-H:%M:%S" -- h:mm:ss
-        , dateTime = "%-d.%m.%Y %-H:%M" -- date + time
+        { date =
+            "%d.%m.%Y"
+            -- dd.MM.yyyy
+        , longDate =
+            "%A, %-d %B %Y"
+            -- dddd, d MMMM yyyy
+        , time =
+            "%-H:%M"
+            -- h:mm
+        , longTime =
+            "%-H:%M:%S"
+            -- h:mm:ss
+        , dateTime =
+            "%-d.%m.%Y %-H:%M"
+            -- date + time
         , firstDayOfWeek = Date.Mon
         }
     }

--- a/src/Date/Extra/Config/Config_pt_br.elm
+++ b/src/Date/Extra/Config/Config_pt_br.elm
@@ -9,6 +9,7 @@ module Date.Extra.Config.Config_pt_br exposing (..)
 import Date
 import Date.Extra.Config as Config
 import Date.Extra.I18n.I_pt_br as Portuguese
+import Date.Extra.I18n.I_default as Default
 
 
 {-| Config for pt-br.
@@ -21,6 +22,7 @@ config =
         , monthShort = Portuguese.monthShort
         , monthName = Portuguese.monthName
         , dayOfMonthWithSuffix = Portuguese.dayOfMonthWithSuffix
+        , twelveHourPeriod = Default.twelveHourPeriod
         }
     , format =
         { date = "%d/%m/%Y"

--- a/src/Date/Extra/Config/Config_ro_ro.elm
+++ b/src/Date/Extra/Config/Config_ro_ro.elm
@@ -11,6 +11,7 @@ Copyright (c) 2016-2017 Cezar Halmagean
 import Date
 import Date.Extra.Config as Config
 import Date.Extra.I18n.I_ro_ro as Romanian
+import Date.Extra.I18n.I_default as Default
 
 
 {-| Config for ro_ro.
@@ -23,13 +24,24 @@ config =
         , monthShort = Romanian.monthShort
         , monthName = Romanian.monthName
         , dayOfMonthWithSuffix = Romanian.dayOfMonthWithSuffix
+        , twelveHourPeriod = Default.twelveHourPeriod
         }
     , format =
-        { date = "%d.%m.%Y" -- dd.MM.yyyy
-        , longDate = "%A, %-d %B %Y" -- dddd, d MMMM yyyy
-        , time = "%-H:%M" -- h:mm
-        , longTime = "%-H:%M:%S" -- h:mm:ss
-        , dateTime = "%-d.%m.%Y %-H:%M" -- date + time
+        { date =
+            "%d.%m.%Y"
+            -- dd.MM.yyyy
+        , longDate =
+            "%A, %-d %B %Y"
+            -- dddd, d MMMM yyyy
+        , time =
+            "%-H:%M"
+            -- h:mm
+        , longTime =
+            "%-H:%M:%S"
+            -- h:mm:ss
+        , dateTime =
+            "%-d.%m.%Y %-H:%M"
+            -- date + time
         , firstDayOfWeek = Date.Mon
         }
     }

--- a/src/Date/Extra/Config/Config_ru_ru.elm
+++ b/src/Date/Extra/Config/Config_ru_ru.elm
@@ -11,6 +11,7 @@ Copyright (c) 2016-2017 Slava Turchaninov
 import Date
 import Date.Extra.Config as Config
 import Date.Extra.I18n.I_ru_ru as Russian
+import Date.Extra.I18n.I_default as Default
 
 
 {-| Config for ru-ru.
@@ -23,13 +24,24 @@ config =
         , monthShort = Russian.monthShort
         , monthName = Russian.monthName
         , dayOfMonthWithSuffix = Russian.dayOfMonthWithSuffix
+        , twelveHourPeriod = Default.twelveHourPeriod
         }
     , format =
-        { date = "%d/%m/%Y" -- d/M/YYY
-        , longDate = "%A, %B %d, %Y" -- dddd, MMMM dd, yyyy
-        , time = "%H:%M" -- H:mm tt
-        , longTime = "%H:%M:%S" -- H:mm:ss
-        , dateTime = "%d/%m/%Y %H:%M" -- date + time
+        { date =
+            "%d/%m/%Y"
+            -- d/M/YYY
+        , longDate =
+            "%A, %B %d, %Y"
+            -- dddd, MMMM dd, yyyy
+        , time =
+            "%H:%M"
+            -- H:mm tt
+        , longTime =
+            "%H:%M:%S"
+            -- H:mm:ss
+        , dateTime =
+            "%d/%m/%Y %H:%M"
+            -- date + time
         , firstDayOfWeek = Date.Mon
         }
     }

--- a/src/Date/Extra/Config/Config_ru_ru.elm
+++ b/src/Date/Extra/Config/Config_ru_ru.elm
@@ -11,7 +11,6 @@ Copyright (c) 2016-2017 Slava Turchaninov
 import Date
 import Date.Extra.Config as Config
 import Date.Extra.I18n.I_ru_ru as Russian
-import Date.Extra.I18n.I_default as Default
 
 
 {-| Config for ru-ru.
@@ -24,7 +23,7 @@ config =
         , monthShort = Russian.monthShort
         , monthName = Russian.monthName
         , dayOfMonthWithSuffix = Russian.dayOfMonthWithSuffix
-        , twelveHourPeriod = Default.twelveHourPeriod
+        , twelveHourPeriod = Russian.twelveHourPeriod
         }
     , format =
         { date =

--- a/src/Date/Extra/Config/Config_tr_tr.elm
+++ b/src/Date/Extra/Config/Config_tr_tr.elm
@@ -11,6 +11,7 @@ Copyright (c) 2017 Mehmet Köse
 import Date
 import Date.Extra.Config as Config
 import Date.Extra.I18n.I_tr_tr as Turkish
+import Date.Extra.I18n.I_default as Default
 
 
 {-| Config for en-us.
@@ -23,23 +24,19 @@ config =
         , monthShort = Turkish.monthShort
         , monthName = Turkish.monthName
         , dayOfMonthWithSuffix = Turkish.dayOfMonthWithSuffix
+        , twelveHourPeriod = Default.twelveHourPeriod
         }
     , format =
         { date =
             "%d.%m.%Y"
-
         , longDate =
             "%d %B %Y %A"
-
         , time =
             "%H:%M"
-
         , longTime =
             "%H:%M:%S"
-
         , dateTime =
             "%d %B %Y %-H:%M:%S"
-
         , firstDayOfWeek = Date.Mon
         }
     }

--- a/src/Date/Extra/Config/Configs.elm
+++ b/src/Date/Extra/Config/Configs.elm
@@ -32,6 +32,7 @@ import Date.Extra.Config.Config_ru_ru as Config_ru_ru
 import Date.Extra.Config.Config_de_de as Config_de_de
 import Date.Extra.Config.Config_tr_tr as Config_tr_tr
 import Date.Extra.Config.Config_lt_lt as Config_lt_lt
+import Date.Extra.Config.Config_el_gr as Config_el_gr
 
 
 {-| Built in configurations.
@@ -54,6 +55,7 @@ configs =
         , ( "de_de", Config_de_de.config )
         , ( "tr_tr", Config_tr_tr.config )
         , ( "lt_lt", Config_lt_lt.config )
+        , ( "el_gr", Config_el_gr.config )
         ]
 
 

--- a/src/Date/Extra/Format.elm
+++ b/src/Date/Extra/Format.elm
@@ -63,6 +63,7 @@ import Date.Extra.Core as Core
 import Date.Extra.Create as Create
 import Date.Extra.Config.Config_en_us as English
 import Date.Extra.Internal as Internal
+import Date.Extra.TwelveHourClock exposing (twelveHourPeriod)
 
 
 {-| ISO date time, 24hr.
@@ -323,16 +324,13 @@ formatToken config offset d m =
                 d |> Date.hour |> hourMod12 |> padWith ' '
 
             "p" ->
-                if Date.hour d < 12 then
-                    "AM"
-                else
-                    "PM"
+                d
+                    |> twelveHourPeriod
+                    |> config.i18n.twelveHourPeriod
+                    |> String.toUpper
 
             "P" ->
-                if Date.hour d < 12 then
-                    "am"
-                else
-                    "pm"
+                d |> twelveHourPeriod |> config.i18n.twelveHourPeriod
 
             "M" ->
                 d |> Date.minute |> padWith '0'

--- a/src/Date/Extra/I18n/I_default.elm
+++ b/src/Date/Extra/I18n/I_default.elm
@@ -1,8 +1,17 @@
 module Date.Extra.I18n.I_default exposing (twelveHourPeriod)
 
+{-| Default values to be reused in multiple language configurations.
+
+@docs twelveHourPeriod
+
+-}
+
 import Date.Extra.TwelveHourClock exposing (TwelveHourPeriod(..))
 
 
+{-| 12-hour clock period (AM/PM) translation and formatting.
+    This should be valid for most latin-based languages.
+-}
 twelveHourPeriod : TwelveHourPeriod -> String
 twelveHourPeriod period =
     case period of

--- a/src/Date/Extra/I18n/I_default.elm
+++ b/src/Date/Extra/I18n/I_default.elm
@@ -1,0 +1,13 @@
+module Date.Extra.I18n.I_default exposing (twelveHourPeriod)
+
+import Date.Extra.TwelveHourClock exposing (TwelveHourPeriod(..))
+
+
+twelveHourPeriod : TwelveHourPeriod -> String
+twelveHourPeriod period =
+    case period of
+        AM ->
+            "AM"
+
+        PM ->
+            "PM"

--- a/src/Date/Extra/I18n/I_el_gr.elm
+++ b/src/Date/Extra/I18n/I_el_gr.elm
@@ -7,8 +7,7 @@ module Date.Extra.I18n.I_el_gr exposing (..)
 @docs monthShort
 @docs monthName
 @docs dayOfMonthWithSuffix
-
-Copyright (c) 2017 Eleni Lixourioti
+@docs twelveHourPeriod
 
 -}
 
@@ -154,6 +153,8 @@ monthName month =
             "Δεκεμβρίου"
 
 
+{-| 12-hour clock period (AM/PM) translation and formatting.
+-}
 twelveHourPeriod : TwelveHourPeriod -> String
 twelveHourPeriod period =
     case period of

--- a/src/Date/Extra/I18n/I_el_gr.elm
+++ b/src/Date/Extra/I18n/I_el_gr.elm
@@ -1,0 +1,173 @@
+module Date.Extra.I18n.I_el_gr exposing (..)
+
+{-| Greek values for day and month names.
+
+@docs dayShort
+@docs dayName
+@docs monthShort
+@docs monthName
+@docs dayOfMonthWithSuffix
+
+Copyright (c) 2017 Eleni Lixourioti
+
+-}
+
+import Date exposing (Day(..), Month(..))
+import Date.Extra.TwelveHourClock exposing (TwelveHourPeriod(..))
+
+
+{-| Day short name.
+-}
+dayShort : Day -> String
+dayShort day =
+    case day of
+        Mon ->
+            "Δευ"
+
+        Tue ->
+            "Τρι"
+
+        Wed ->
+            "Τετ"
+
+        Thu ->
+            "Πεμ"
+
+        Fri ->
+            "Παρ"
+
+        Sat ->
+            "Σαβ"
+
+        Sun ->
+            "Κυρ"
+
+
+{-| Day full name.
+-}
+dayName : Day -> String
+dayName day =
+    case day of
+        Mon ->
+            "Δευτέρα"
+
+        Tue ->
+            "Τρίτη"
+
+        Wed ->
+            "Τετάρτη"
+
+        Thu ->
+            "Πέμπτη"
+
+        Fri ->
+            "Παρασκευή"
+
+        Sat ->
+            "Σάββατο"
+
+        Sun ->
+            "Κυριακή"
+
+
+{-| Month short name.
+-}
+monthShort : Month -> String
+monthShort month =
+    case month of
+        Jan ->
+            "Ιαν"
+
+        Feb ->
+            "Φεβ"
+
+        Mar ->
+            "Μαρ"
+
+        Apr ->
+            "Απρ"
+
+        May ->
+            "Μαϊ"
+
+        Jun ->
+            "Ιουν"
+
+        Jul ->
+            "Ιουλ"
+
+        Aug ->
+            "Αυγ"
+
+        Sep ->
+            "Σεπ"
+
+        Oct ->
+            "Οκτ"
+
+        Nov ->
+            "Νοε"
+
+        Dec ->
+            "Δεκ"
+
+
+{-| Month full name.
+-}
+monthName : Month -> String
+monthName month =
+    case month of
+        Jan ->
+            "Ιανουαρίου"
+
+        Feb ->
+            "Φεβρουαρίου"
+
+        Mar ->
+            "Μαρτίου"
+
+        Apr ->
+            "Απριλίου"
+
+        May ->
+            "Μαΐου"
+
+        Jun ->
+            "Ιουνίου"
+
+        Jul ->
+            "Ιουλίου"
+
+        Aug ->
+            "Αυγούστου"
+
+        Sep ->
+            "Σεπτεμβρίου"
+
+        Oct ->
+            "Οκτωβρίου"
+
+        Nov ->
+            "Νοεμβρίου"
+
+        Dec ->
+            "Δεκεμβρίου"
+
+
+twelveHourPeriod : TwelveHourPeriod -> String
+twelveHourPeriod period =
+    case period of
+        AM ->
+            "π.μ."
+
+        PM ->
+            "μ.μ."
+
+
+{-| No known special rules for Greek
+-}
+dayOfMonthWithSuffix : Bool -> Int -> String
+dayOfMonthWithSuffix pad day =
+    case day of
+        _ ->
+            (toString day)

--- a/src/Date/Extra/I18n/I_ru_ru.elm
+++ b/src/Date/Extra/I18n/I_ru_ru.elm
@@ -13,7 +13,7 @@ Copyright (c) 2017 Slava Turchaninov
 -}
 
 import Date exposing (Day(..), Month(..))
-import String exposing (padLeft)
+import Date.Extra.TwelveHourClock exposing (TwelveHourPeriod(..))
 
 
 {-| Day short name.
@@ -152,6 +152,16 @@ monthName month =
 
         Dec ->
             "Декабрь"
+
+
+twelveHourPeriod : TwelveHourPeriod -> String
+twelveHourPeriod period =
+    case period of
+        AM ->
+            "дп"
+
+        PM ->
+            "пп"
 
 
 {-| Just convert to string

--- a/src/Date/Extra/I18n/I_ru_ru.elm
+++ b/src/Date/Extra/I18n/I_ru_ru.elm
@@ -7,6 +7,7 @@ module Date.Extra.I18n.I_ru_ru exposing (..)
 @docs monthShort
 @docs monthName
 @docs dayOfMonthWithSuffix
+@docs twelveHourPeriod
 
 Copyright (c) 2017 Slava Turchaninov
 
@@ -154,6 +155,8 @@ monthName month =
             "Декабрь"
 
 
+{-| 12-hour clock period (AM/PM) translation and formatting.
+-}
 twelveHourPeriod : TwelveHourPeriod -> String
 twelveHourPeriod period =
     case period of

--- a/src/Date/Extra/TwelveHourClock.elm
+++ b/src/Date/Extra/TwelveHourClock.elm
@@ -1,0 +1,25 @@
+module Date.Extra.TwelveHourClock
+    exposing
+        ( TwelveHourPeriod(..)
+        , twelveHourPeriod
+        )
+
+import Date
+
+
+-- 12-Hour Clock --
+
+
+{-| 12-Hour clock abbreviations (AM/PM)
+-}
+type TwelveHourPeriod
+    = AM
+    | PM
+
+
+twelveHourPeriod : Date.Date -> TwelveHourPeriod
+twelveHourPeriod d =
+    if Date.hour d < 12 then
+        AM
+    else
+        PM

--- a/tests/Date/Extra/ConfigTests.elm
+++ b/tests/Date/Extra/ConfigTests.elm
@@ -18,6 +18,7 @@ import Date.Extra.Config.Config_ru_ru as Config_ru_ru
 import Date.Extra.Config.Config_de_de as Config_de_de
 import Date.Extra.Config.Config_tr_tr as Config_tr_tr
 import Date.Extra.Config.Config_lt_lt as Config_lt_lt
+import Date.Extra.Config.Config_el_gr as Config_el_gr
 import Date.Extra.Config.Configs as Configs
 
 
@@ -79,6 +80,10 @@ config_tr_tr =
 
 config_lt_lt =
     Config_lt_lt.config
+
+
+config_el_gr =
+    Config_el_gr.config
 
 
 tests : Test
@@ -169,4 +174,9 @@ tests =
                 Expect.equal
                     config_lt_lt.format
                     (Configs.getConfig "lt_lt").format
+        , test "getConfig el_gr" <|
+            \() ->
+                Expect.equal
+                    config_el_gr.format
+                    (Configs.getConfig "el_gr").format
         ]

--- a/tests/Date/Extra/FormatTests.elm
+++ b/tests/Date/Extra/FormatTests.elm
@@ -23,6 +23,7 @@ import Date.Extra.Config.Config_ru_ru as Config_ru_ru
 import Date.Extra.Config.Config_de_de as Config_de_de
 import Date.Extra.Config.Config_tr_tr as Config_tr_tr
 import Date.Extra.Config.Config_lt_lt as Config_lt_lt
+import Date.Extra.Config.Config_el_gr as Config_el_gr
 import Date.Extra.Period as DPeriod exposing (Period(Hour))
 
 
@@ -84,6 +85,10 @@ config_tr_tr =
 
 config_lt_lt =
     Config_lt_lt.config
+
+
+config_el_gr =
+    Config_el_gr.config
 
 
 tests : Test
@@ -200,9 +205,8 @@ formatTestCases =
     , ( "with %% ", "% 12/08/2014", "%% %d/%m/%Y", aTestTime )
     , ( "with %% no space", " %12/08/2014", " %%%d/%m/%Y", aTestTime )
     , ( "with milliseconds", "2014-08-12 (.116)", "%Y-%m-%d (.%L)", aTestTime )
-
-    -- in EDT GMT-04:00
-    -- Tue Aug 12 2014 04:53:51 GMT-0400 (Eastern Daylight Time)
+      -- in EDT GMT-04:00
+      -- Tue Aug 12 2014 04:53:51 GMT-0400 (Eastern Daylight Time)
     , ( "with milliseconds 2", "2014-08-12T18:53:51.116", "%Y-%m-%dT%H:%M:%S.%L", aTestTime )
     , ( "small year", "0448-09-09T22:39:28.884", "%Y-%m-%dT%H:%M:%S.%L", aTestTime3 )
     , ( "Config_en_us date", "8/5/2014", config_en_us.format.date, aTestTime5 )
@@ -218,9 +222,8 @@ formatTestCases =
     , ( "Config_en_au longTime", "5:53:51 AM", config_en_au.format.longTime, aTestTime5 )
     , ( "Config_en_au dateTime", "5/08/2014 5:53 AM", config_en_au.format.dateTime, aTestTime5 )
     , ( "Config_en_us date", "8/12/2014", config_en_us.format.date, aTestTime )
-
-    -- year rendered negative ? boggle :) disabled for not supporting at moment
-    --, ("small year", "0448-09-09T22:39:28.885", "%Y-%m-%dT%H:%M:%S.%L", aTestTime4)
+      -- year rendered negative ? boggle :) disabled for not supporting at moment
+      --, ("small year", "0448-09-09T22:39:28.885", "%Y-%m-%dT%H:%M:%S.%L", aTestTime4)
     , ( "Check day 12 ordinal date format with out padding", "[12][12th]", "[%-d][%-@d]", aTestTime )
     , ( "Check day 12 ordinal date format with padding", "[12][12th]", "[%e][%@e]", aTestTime )
     , ( "Check day 2 ordinal date format with out padding", "[2][2nd]", "[%-d][%-@d]", aTestTime8 )
@@ -282,6 +285,9 @@ formatConfigTestCases =
     , ( "Config_de_de longDate idiom", "Dienstag, 5. August 2014", config_de_de, config_de_de.format.longDate, aTestTime5 )
     , ( "Config_tr_tr date idiom", "05.08.2014", config_tr_tr, config_tr_tr.format.date, aTestTime5 )
     , ( "Config_tr_tr longDate idiom", "05 Ağustos 2014 Salı", config_tr_tr, config_tr_tr.format.longDate, aTestTime5 )
+    , ( "Config_el_gr date idiom", "5/8/14", config_el_gr, config_el_gr.format.date, aTestTime5 )
+    , ( "Config_el_gr longDate idiom", "Τρίτη, 5 Αυγούστου 2014", config_el_gr, config_el_gr.format.longDate, aTestTime5 )
+    , ( "Config_el_gr time idiom", "5:53 π.μ.", config_el_gr, config_el_gr.format.time, aTestTime5 )
     ]
 
 

--- a/tests/Date/Extra/FormatTests.elm
+++ b/tests/Date/Extra/FormatTests.elm
@@ -281,6 +281,7 @@ formatConfigTestCases =
     , ( "Config_ru_ru day idiom", "05/08/2014", config_ru_ru, config_ru_ru.format.date, aTestTime5 )
     , ( "Config_ru_ru format idiom", "Вторник (5) 05 Август 2014", config_ru_ru, dayDayIdiomMonth, aTestTime5 )
     , ( "Config_ru_ru time idiom", "05:53", config_ru_ru, config_ru_ru.format.time, aTestTime5 )
+    , ( "Config_ru_ru time with am/pm", "5:53 ДП", config_ru_ru, "%-I:%M %p", aTestTime5 )
     , ( "Config_de_de date idiom", "5. August 2014", config_de_de, config_de_de.format.date, aTestTime5 )
     , ( "Config_de_de longDate idiom", "Dienstag, 5. August 2014", config_de_de, config_de_de.format.longDate, aTestTime5 )
     , ( "Config_tr_tr date idiom", "05.08.2014", config_tr_tr, config_tr_tr.format.date, aTestTime5 )


### PR DESCRIPTION
Hi!

This PR is to adding i18n support for am/pm 🕐 as well as support for Greek 🇬🇷 

I wanted to just add a Greek configuration to this library, but I very soon realised that the short time format in Greek is using a 12-hour clock  format (aka AM/PM). Even though the library currently supports AM/PM as strings, it's only kind of valid for languages that use the latin format.

The rationale behind some of the changes:

* I added a separate file for 12-hour clock related stuff, which I tried to avoid by initially adding everything to `Date.Extra.TimeUnit` or other logically compatible modules instead but in many cases I ran into circular import problems (because of calls to `Date.Extra.Format` and some defaults coming explicitly from the English language).

* One of the things I added was the idea of "default"  formats, (`I_default`). If you like this idea then I think it could be a good base for subsequent work, as some of the English settings could in theory move there, so that explicit calls to English from `Format` are no longer needed.  But if you really don't like it I could remove `I_default` and add a function in every single language file that returns "AM" and "PM".

* `elm-format` (which I run by default) caused some indentation fixes in some of the files I touched. Again let me know if this is ok.

As a subsequent test to the AM/PM I also added the Russian 🇷🇺  abbreviations (though as far as I know they are not very widely used). Some other uses of this feature would be for languages that might use "AM" and "PM" as well, but maybe in a slightly different default format (ex. by requiring dots like "5 a.m.", which I believe is standard for Spanish).


PS. Another thing that I uncovered was that certain languages, like Greek and Russian, might require months with different suffixes/formats. I have added a TODO in the Greek config, but I think solving that issue might be more complex, as the formatting has to become context aware (e.g. is the month name next to a day?). You can see those types in the ICU references below under month names *"Formatting"* and *"Standalone"* subsections. Another issue for another PR...

Refs:
[ICU Greek](http://demo.icu-project.org/icu-bin/locexp?d_=en&_=el_GR)
[ICU Russian](http://demo.icu-project.org/icu-bin/locexp?d_=en&_=ru_RU)
[ICU Spanish](http://demo.icu-project.org/icu-bin/locexp?d_=en&_=es_ES)