### PR TITLE
Fix Russian localizations as most of them were wrong; add Swedish localization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 elm-stuff/
+.idea/
 elm.js
 index.html
 tests/program.js

--- a/src/Date/Extra/Config/Config_sv_se.elm
+++ b/src/Date/Extra/Config/Config_sv_se.elm
@@ -1,0 +1,33 @@
+module Date.Extra.Config.Config_sv_se exposing (config)
+
+{-| This is the Swedish config for formatting dates.
+@docs config
+-}
+
+import Date
+import Date.Extra.Config as Config
+import Date.Extra.I18n.I_default as Default
+import Date.Extra.I18n.I_sv_se as Swedish
+
+
+{-| Config for sv-se.
+-}
+config : Config.Config
+config =
+    { i18n =
+        { dayShort = Swedish.dayShort
+        , dayName = Swedish.dayName
+        , monthShort = Swedish.monthShort
+        , monthName = Swedish.monthName
+        , dayOfMonthWithSuffix = Swedish.dayOfMonthWithSuffix
+        , twelveHourPeriod = Default.twelveHourPeriod
+        }
+    , format =
+        { date = "%Y-%m-%d" -- YYYY-MM-DD (L equivalent in moment.js)
+        , longDate = "%A %-d %B %Y" -- dddd D MMMM YYYY
+        , time = "%H:%M" -- HH:mm
+        , longTime = "%H:%M:%S" -- HH:mm:ss
+        , dateTime = "%Y-%m-%d %H:%M" -- YYYY-MM-DD HH:mm
+        , firstDayOfWeek = Date.Mon
+        }
+    }

--- a/src/Date/Extra/Config/Configs.elm
+++ b/src/Date/Extra/Config/Configs.elm
@@ -1,7 +1,7 @@
 module Date.Extra.Config.Configs
     exposing
-        ( getConfig
-        , configs
+        ( configs
+        , getConfig
         )
 
 {-| Get a Date Extra Config based up on a locale code.
@@ -13,26 +13,27 @@ Copyright (c) 2016-2017 Robin Luiten
 
 -}
 
-import Dict exposing (Dict)
-import Regex exposing (replace, regex, HowMany(All))
-import String
 import Date.Extra.Config as Config exposing (Config)
-import Date.Extra.Config.Config_en_au as Config_en_au
-import Date.Extra.Config.Config_en_us as Config_en_us
-import Date.Extra.Config.Config_en_gb as Config_en_gb
-import Date.Extra.Config.Config_fr_fr as Config_fr_fr
-import Date.Extra.Config.Config_fi_fi as Config_fi_fi
-import Date.Extra.Config.Config_pl_pl as Config_pl_pl
-import Date.Extra.Config.Config_ro_ro as Config_ro_ro
-import Date.Extra.Config.Config_nl_nl as Config_nl_nl
-import Date.Extra.Config.Config_pt_br as Config_pt_br
-import Date.Extra.Config.Config_et_ee as Config_et_ee
-import Date.Extra.Config.Config_ja_jp as Config_ja_jp
-import Date.Extra.Config.Config_ru_ru as Config_ru_ru
 import Date.Extra.Config.Config_de_de as Config_de_de
-import Date.Extra.Config.Config_tr_tr as Config_tr_tr
-import Date.Extra.Config.Config_lt_lt as Config_lt_lt
 import Date.Extra.Config.Config_el_gr as Config_el_gr
+import Date.Extra.Config.Config_en_au as Config_en_au
+import Date.Extra.Config.Config_en_gb as Config_en_gb
+import Date.Extra.Config.Config_en_us as Config_en_us
+import Date.Extra.Config.Config_et_ee as Config_et_ee
+import Date.Extra.Config.Config_fi_fi as Config_fi_fi
+import Date.Extra.Config.Config_fr_fr as Config_fr_fr
+import Date.Extra.Config.Config_ja_jp as Config_ja_jp
+import Date.Extra.Config.Config_lt_lt as Config_lt_lt
+import Date.Extra.Config.Config_nl_nl as Config_nl_nl
+import Date.Extra.Config.Config_pl_pl as Config_pl_pl
+import Date.Extra.Config.Config_pt_br as Config_pt_br
+import Date.Extra.Config.Config_ro_ro as Config_ro_ro
+import Date.Extra.Config.Config_ru_ru as Config_ru_ru
+import Date.Extra.Config.Config_sv_se as Config_sv_se
+import Date.Extra.Config.Config_tr_tr as Config_tr_tr
+import Dict exposing (Dict)
+import Regex exposing (HowMany(All), regex, replace)
+import String
 
 
 {-| Built in configurations.
@@ -56,6 +57,7 @@ configs =
         , ( "tr_tr", Config_tr_tr.config )
         , ( "lt_lt", Config_lt_lt.config )
         , ( "el_gr", Config_el_gr.config )
+        , ( "sv_se", Config_sv_se.config )
         ]
 
 
@@ -76,5 +78,5 @@ getConfig id =
         fixedId =
             replace All (regex "-") (\_ -> "_") lowerId
     in
-        Maybe.withDefault Config_en_us.config
-            (Dict.get fixedId configs)
+    Maybe.withDefault Config_en_us.config
+        (Dict.get fixedId configs)

--- a/src/Date/Extra/I18n/I_ru_ru.elm
+++ b/src/Date/Extra/I18n/I_ru_ru.elm
@@ -9,8 +9,6 @@ module Date.Extra.I18n.I_ru_ru exposing (..)
 @docs dayOfMonthWithSuffix
 @docs twelveHourPeriod
 
-Copyright (c) 2017 Slava Turchaninov
-
 -}
 
 import Date exposing (Day(..), Month(..))
@@ -23,25 +21,25 @@ dayShort : Day -> String
 dayShort day =
     case day of
         Mon ->
-            "Пн"
+            "пн."
 
         Tue ->
-            "Вт"
+            "вт."
 
         Wed ->
-            "Ср"
+            "ср."
 
         Thu ->
-            "Чт"
+            "чт."
 
         Fri ->
-            "Пт"
+            "пт."
 
         Sat ->
-            "Сб"
+            "сб."
 
         Sun ->
-            "Вс"
+            "вс."
 
 
 {-| Day full name.
@@ -50,67 +48,70 @@ dayName : Day -> String
 dayName day =
     case day of
         Mon ->
-            "Понедельник"
+            "понедельник"
 
         Tue ->
-            "Вторник"
+            "вторник"
 
         Wed ->
-            "Среда"
+            "среда"
 
         Thu ->
-            "Четверг"
+            "четверг"
 
         Fri ->
-            "Пятница"
+            "пятница"
 
         Sat ->
-            "Суббота"
+            "суббота"
 
         Sun ->
-            "Воскресенье"
+            "воскресенье"
 
 
 {-| Month short name.
+sources:
+<http://new.gramota.ru/spravka/buro/search-answer?s=242637>
+<http://www.unicode.org/cldr/charts/28/summary/ru.html#1753>
 -}
 monthShort : Month -> String
 monthShort month =
     case month of
         Jan ->
-            "Янв"
+            "янв."
 
         Feb ->
-            "Фев"
+            "февр."
 
         Mar ->
-            "Мар"
+            "март"
 
         Apr ->
-            "Апр"
+            "апр."
 
         May ->
-            "Май"
+            "май"
 
         Jun ->
-            "Июн"
+            "июнь."
 
         Jul ->
-            "Июл"
+            "июль."
 
         Aug ->
-            "Авг"
+            "авг."
 
         Sep ->
-            "Сен"
+            "сент."
 
         Oct ->
-            "Окт"
+            "окт."
 
         Nov ->
-            "Ноя"
+            "нояб."
 
         Dec ->
-            "Дек"
+            "дек."
 
 
 {-| Month full name.
@@ -119,40 +120,40 @@ monthName : Month -> String
 monthName month =
     case month of
         Jan ->
-            "Январь"
+            "январь"
 
         Feb ->
-            "Февраль"
+            "февраль"
 
         Mar ->
-            "Март"
+            "март"
 
         Apr ->
-            "Апрель"
+            "апрель"
 
         May ->
-            "Май"
+            "май"
 
         Jun ->
-            "Июнь"
+            "июнь"
 
         Jul ->
-            "Июль"
+            "июль"
 
         Aug ->
-            "Август"
+            "август"
 
         Sep ->
-            "Сентябрь"
+            "сентябрь"
 
         Oct ->
-            "Октябрь"
+            "октябрь"
 
         Nov ->
-            "Ноябрь"
+            "ноябрь"
 
         Dec ->
-            "Декабрь"
+            "декабрь"
 
 
 {-| 12-hour clock period (AM/PM) translation and formatting.
@@ -173,4 +174,4 @@ dayOfMonthWithSuffix : Bool -> Int -> String
 dayOfMonthWithSuffix pad day =
     case day of
         _ ->
-            (toString day)
+            toString day

--- a/src/Date/Extra/I18n/I_sv_se.elm
+++ b/src/Date/Extra/I18n/I_sv_se.elm
@@ -1,0 +1,162 @@
+module Date.Extra.I18n.I_sv_se exposing (..)
+
+{-| Finnish values for day and month names.
+
+@docs dayShort
+@docs dayName
+@docs monthShort
+@docs monthName
+@docs dayOfMonthWithSuffix
+
+Copyright (c) 2016 Ossi Hanhinen
+
+-}
+
+import Date exposing (Day(..), Month(..))
+
+
+{-| Day short name.
+-}
+dayShort : Day -> String
+dayShort day =
+    case day of
+        Mon ->
+            "mån"
+
+        Tue ->
+            "tis"
+
+        Wed ->
+            "ons"
+
+        Thu ->
+            "tor"
+
+        Fri ->
+            "fre"
+
+        Sat ->
+            "lör"
+
+        Sun ->
+            "sön"
+
+
+{-| Day full name.
+-}
+dayName : Day -> String
+dayName day =
+    case day of
+        Mon ->
+            "måndag"
+
+        Tue ->
+            "tisdag"
+
+        Wed ->
+            "onsdag"
+
+        Thu ->
+            "torsdag"
+
+        Fri ->
+            "fredag"
+
+        Sat ->
+            "lördag"
+
+        Sun ->
+            "lördag"
+
+
+{-| Month short name.
+-}
+monthShort : Month -> String
+monthShort month =
+    case month of
+        Jan ->
+            "jan"
+
+        Feb ->
+            "feb"
+
+        Mar ->
+            "mar"
+
+        Apr ->
+            "apr"
+
+        May ->
+            "maj"
+
+        Jun ->
+            "jun"
+
+        Jul ->
+            "jul"
+
+        Aug ->
+            "aug"
+
+        Sep ->
+            "sep"
+
+        Oct ->
+            "okt"
+
+        Nov ->
+            "nov"
+
+        Dec ->
+            "dec"
+
+
+{-| Month full name.
+-}
+monthName : Month -> String
+monthName month =
+    case month of
+        Jan ->
+            "januari"
+
+        Feb ->
+            "februari"
+
+        Mar ->
+            "mars"
+
+        Apr ->
+            "april"
+
+        May ->
+            "maj"
+
+        Jun ->
+            "juni"
+
+        Jul ->
+            "juli"
+
+        Aug ->
+            "augusti"
+
+        Sep ->
+            "september"
+
+        Oct ->
+            "oktober"
+
+        Nov ->
+            "november"
+
+        Dec ->
+            "december"
+
+
+{-| Nothing done here for now, but it might be needed
+-}
+dayOfMonthWithSuffix : Bool -> Int -> String
+dayOfMonthWithSuffix pad day =
+    case day of
+        _ ->
+            toString day

--- a/tests/Date/Extra/ConfigTests.elm
+++ b/tests/Date/Extra/ConfigTests.elm
@@ -1,25 +1,26 @@
 module Date.Extra.ConfigTests exposing (..)
 
 import Date exposing (Date)
-import Test exposing (..)
-import Expect
-import Date.Extra.Config.Config_en_au as Config_en_au
-import Date.Extra.Config.Config_en_us as Config_en_us
-import Date.Extra.Config.Config_en_gb as Config_en_gb
-import Date.Extra.Config.Config_fr_fr as Config_fr_fr
-import Date.Extra.Config.Config_fi_fi as Config_fi_fi
-import Date.Extra.Config.Config_pl_pl as Config_pl_pl
-import Date.Extra.Config.Config_ro_ro as Config_ro_ro
-import Date.Extra.Config.Config_nl_nl as Config_nl_nl
-import Date.Extra.Config.Config_pt_br as Config_pt_br
-import Date.Extra.Config.Config_et_ee as Config_et_ee
-import Date.Extra.Config.Config_ja_jp as Config_ja_jp
-import Date.Extra.Config.Config_ru_ru as Config_ru_ru
 import Date.Extra.Config.Config_de_de as Config_de_de
-import Date.Extra.Config.Config_tr_tr as Config_tr_tr
-import Date.Extra.Config.Config_lt_lt as Config_lt_lt
 import Date.Extra.Config.Config_el_gr as Config_el_gr
+import Date.Extra.Config.Config_en_au as Config_en_au
+import Date.Extra.Config.Config_en_gb as Config_en_gb
+import Date.Extra.Config.Config_en_us as Config_en_us
+import Date.Extra.Config.Config_et_ee as Config_et_ee
+import Date.Extra.Config.Config_fi_fi as Config_fi_fi
+import Date.Extra.Config.Config_fr_fr as Config_fr_fr
+import Date.Extra.Config.Config_ja_jp as Config_ja_jp
+import Date.Extra.Config.Config_lt_lt as Config_lt_lt
+import Date.Extra.Config.Config_nl_nl as Config_nl_nl
+import Date.Extra.Config.Config_pl_pl as Config_pl_pl
+import Date.Extra.Config.Config_pt_br as Config_pt_br
+import Date.Extra.Config.Config_ro_ro as Config_ro_ro
+import Date.Extra.Config.Config_ru_ru as Config_ru_ru
+import Date.Extra.Config.Config_sv_se as Config_sv_se
+import Date.Extra.Config.Config_tr_tr as Config_tr_tr
 import Date.Extra.Config.Configs as Configs
+import Expect
+import Test exposing (..)
 
 
 config_en_au =
@@ -40,6 +41,10 @@ config_fr_fr =
 
 config_fi_fi =
     Config_fi_fi.config
+
+
+config_sv_se =
+    Config_sv_se.config
 
 
 config_pl_pl =
@@ -124,6 +129,11 @@ tests =
                 Expect.equal
                     config_fi_fi.format
                     (Configs.getConfig "fi_fi").format
+        , test "getConfig sv_se" <|
+            \() ->
+                Expect.equal
+                    config_sv_se.format
+                    (Configs.getConfig "sv_se").format
         , test "getConfig pl_pl" <|
             \() ->
                 Expect.equal

--- a/tests/Date/Extra/FormatTests.elm
+++ b/tests/Date/Extra/FormatTests.elm
@@ -281,7 +281,7 @@ formatConfigTestCases =
     , ( "Config_ja_jp day idiom", "2014/8/5", config_ja_jp, config_ja_jp.format.date, aTestTime5 )
     , ( "Config_ja_jp format idiom", "火曜日 (5) 05 8月 2014", config_ja_jp, dayDayIdiomMonth, aTestTime5 )
     , ( "Config_ru_ru day idiom", "05/08/2014", config_ru_ru, config_ru_ru.format.date, aTestTime5 )
-    , ( "Config_ru_ru format idiom", "Вторник (5) 05 Август 2014", config_ru_ru, dayDayIdiomMonth, aTestTime5 )
+    , ( "Config_ru_ru format idiom", "вторник (5) 05 август 2014", config_ru_ru, dayDayIdiomMonth, aTestTime5 )
     , ( "Config_ru_ru time idiom", "05:53", config_ru_ru, config_ru_ru.format.time, aTestTime5 )
     , ( "Config_ru_ru time with am/pm", "5:53 ДП", config_ru_ru, "%-I:%M %p", aTestTime5 )
     , ( "Config_de_de date idiom", "5. August 2014", config_de_de, config_de_de.format.date, aTestTime5 )

--- a/tests/Date/Extra/FormatTests.elm
+++ b/tests/Date/Extra/FormatTests.elm
@@ -18,6 +18,7 @@ import Date.Extra.Config.Config_pl_pl as Config_pl_pl
 import Date.Extra.Config.Config_pt_br as Config_pt_br
 import Date.Extra.Config.Config_ro_ro as Config_ro_ro
 import Date.Extra.Config.Config_ru_ru as Config_ru_ru
+import Date.Extra.Config.Config_sv_se as Config_sv_se
 import Date.Extra.Config.Config_tr_tr as Config_tr_tr
 import Date.Extra.Core as Core
 import Date.Extra.Format as Format
@@ -45,6 +46,10 @@ config_fr_fr =
 
 config_fi_fi =
     Config_fi_fi.config
+
+
+config_sv_se =
+    Config_sv_se.config
 
 
 config_pl_pl =
@@ -264,6 +269,21 @@ formatConfigTestCases =
     , ( "Config_fr_fr format idiom", "Mardi (  5) 05 Août 2014", config_fr_fr, dayDayIdiomMonth, aTestTime5 )
     , ( "Config_fi_fi day idiom", "5.8.2014", config_fi_fi, config_fi_fi.format.date, aTestTime5 )
     , ( "Config_fi_fi format idiom", "tiistai (5) 05 elokuuta 2014", config_fi_fi, dayDayIdiomMonth, aTestTime5 )
+    , ( "Config_sv_se day idiom", "2014-08-05", config_sv_se, config_sv_se.format.date, aTestTime5 )
+    , ( "Config_sv_se long date idiom"
+      , "tisdag 5 augusti 2014"
+      , config_sv_se
+      , config_sv_se.format.longDate
+      , aTestTime5
+      )
+    , ( "Config_sv_se date time idiom"
+      , "2014-08-05 05:53"
+      , config_sv_se
+      , config_sv_se.format.dateTime
+      , aTestTime5
+      )
+    , ( "Config_sv_se format idiom", "tisdag (5) 05 augusti 2014", config_sv_se, dayDayIdiomMonth, aTestTime5 )
+    , ( "Config_sv_se time idiom", "17:00", config_sv_se, config_sv_se.format.time, aTestTime8 )
     , ( "Config_pl_pl day idiom", "05.08.2014", config_pl_pl, config_pl_pl.format.date, aTestTime5 )
     , ( "Config_pl_pl format idiom", "wtorek (5) 05 sierpień 2014", config_pl_pl, dayDayIdiomMonth, aTestTime5 )
     , ( "Config_ro_ro day idiom", "05.08.2014", config_ro_ro, config_ro_ro.format.date, aTestTime5 )

--- a/tests/Date/Extra/FormatTests.elm
+++ b/tests/Date/Extra/FormatTests.elm
@@ -3,28 +3,28 @@ module Date.Extra.FormatTests exposing (..)
 {- Test date format. -}
 
 import Date exposing (Date)
-import Test exposing (..)
-import Expect
-import Time exposing (Time)
+import Date.Extra.Config.Config_de_de as Config_de_de
+import Date.Extra.Config.Config_el_gr as Config_el_gr
+import Date.Extra.Config.Config_en_au as Config_en_au
+import Date.Extra.Config.Config_en_gb as Config_en_gb
+import Date.Extra.Config.Config_en_us as Config_en_us
+import Date.Extra.Config.Config_et_ee as Config_et_ee
+import Date.Extra.Config.Config_fi_fi as Config_fi_fi
+import Date.Extra.Config.Config_fr_fr as Config_fr_fr
+import Date.Extra.Config.Config_ja_jp as Config_ja_jp
+import Date.Extra.Config.Config_lt_lt as Config_lt_lt
+import Date.Extra.Config.Config_nl_nl as Config_nl_nl
+import Date.Extra.Config.Config_pl_pl as Config_pl_pl
+import Date.Extra.Config.Config_pt_br as Config_pt_br
+import Date.Extra.Config.Config_ro_ro as Config_ro_ro
+import Date.Extra.Config.Config_ru_ru as Config_ru_ru
+import Date.Extra.Config.Config_tr_tr as Config_tr_tr
 import Date.Extra.Core as Core
 import Date.Extra.Format as Format
-import Date.Extra.Config.Config_en_au as Config_en_au
-import Date.Extra.Config.Config_en_us as Config_en_us
-import Date.Extra.Config.Config_en_gb as Config_en_gb
-import Date.Extra.Config.Config_fr_fr as Config_fr_fr
-import Date.Extra.Config.Config_fi_fi as Config_fi_fi
-import Date.Extra.Config.Config_pl_pl as Config_pl_pl
-import Date.Extra.Config.Config_ro_ro as Config_ro_ro
-import Date.Extra.Config.Config_nl_nl as Config_nl_nl
-import Date.Extra.Config.Config_pt_br as Config_pt_br
-import Date.Extra.Config.Config_et_ee as Config_et_ee
-import Date.Extra.Config.Config_ja_jp as Config_ja_jp
-import Date.Extra.Config.Config_ru_ru as Config_ru_ru
-import Date.Extra.Config.Config_de_de as Config_de_de
-import Date.Extra.Config.Config_tr_tr as Config_tr_tr
-import Date.Extra.Config.Config_lt_lt as Config_lt_lt
-import Date.Extra.Config.Config_el_gr as Config_el_gr
 import Date.Extra.Period as DPeriod exposing (Period(Hour))
+import Expect
+import Test exposing (..)
+import Time exposing (Time)
 
 
 config_en_au =
@@ -192,11 +192,11 @@ runFormatTest ( name, expected, formatStr, time ) =
         --   , "format", (Format.formatOffset Config_en_us.config -600 formatStr asDate)
         --   )
     in
-        test name <|
-            \() ->
-                Expect.equal
-                    expected
-                    (Format.formatOffset Config_en_us.config -600 formatStr asDate)
+    test name <|
+        \() ->
+            Expect.equal
+                expected
+                (Format.formatOffset Config_en_us.config -600 formatStr asDate)
 
 
 formatTestCases =
@@ -240,11 +240,11 @@ runConfigLanguageTest ( name, expected, config, formatStr, time ) =
         asDate =
             Core.fromTime time
     in
-        test name <|
-            \() ->
-                Expect.equal
-                    expected
-                    (Format.formatOffset config -600 formatStr asDate)
+    test name <|
+        \() ->
+            Expect.equal
+                expected
+                (Format.formatOffset config -600 formatStr asDate)
 
 
 {-| These tests are testing a few language field values and the day idiom function.


### PR DESCRIPTION
First of all, in Russian, none of the month names or weekdays names are capitalized (unless at the start of the sentence). Second, mostly all of the abbreviations here were wrong, here are the links to some sources backing this claim up:

http://new.gramota.ru/spravka/buro/search-answer?s=242637 (here the question lists the wrong format and the answer lists the correct format of the abbreviations)

http://www.unicode.org/cldr/charts/28/summary/ru.html#1753 (here it's possible to find all the full names of months and weekdays and all of the abbreviations, too)
