### PR TITLE
2 failing tests to illustrate a problem with Duration.diff

### DIFF
--- a/tests/Date/Extra/DurationTests.elm
+++ b/tests/Date/Extra/DurationTests.elm
@@ -54,6 +54,34 @@ tests =
                 )
               )
             ]
+        , describe "Duration.diff on directly created dates"
+            [ test "2019-01-01 — 2018-01-11T21:00:00" <|
+                \_ ->
+                    let
+                        y2019m01d01 =
+                            Date.fromTime 1546300800000
+
+                        y2018m01d11h21 =
+                            Date.fromTime 1515704400000
+
+                        d =
+                            Duration.diff y2019m01d01 y2018m01d11h21
+                    in
+                        Expect.equal d (Duration.DeltaRecord 0 11 20 3 0 0 0)
+            , test "2019-01-11 — 2018-01-11T21:00:00" <|
+                \_ ->
+                    let
+                        y2019m01d11 =
+                            Date.fromTime 1547164800000
+
+                        y2018m01d11h21 =
+                            Date.fromTime 1515704400000
+
+                        d =
+                            Duration.diff y2019m01d11 y2018m01d11h21
+                    in
+                        Expect.equal d (Duration.DeltaRecord 0 11 30 3 0 0 0)
+            ]
         ]
 
 


### PR DESCRIPTION
Case 1: 2019-01-01 — 2018-01-11T21:00:00

```
> subtrahend = moment.utc(1546300800000)
moment.utc("2019-01-01T00:00:00.000+00:00")
> minuend = moment.utc(1515704400000)
moment.utc("2018-01-11T21:00:00.000+00:00")
> minuend.add({months: 11, days: 20, hours: 3})
moment.utc("2019-01-01T00:00:00.000+00:00")
```

However, `Duration.diff` returns -1 month instead

```
↓ Duration.diff on directly created dates
✗ 2019-01-01 — 2018-01-11T21:00:00

    { year = 0, month = 11, day = 20, hour = 3, minute = 0, second = 0, millisecond = 0 }
    ╷
    │ Expect.equal
    ╵
    { year = 1, month = -1, day = 20, hour = 3, minute = 0, second = 0, millisecond = 0 }
```

Case 2: 2019-01-11 — 2018-01-11T21:00:00

```
> subtrahend = moment.utc(1547164800000)
moment.utc("2019-01-11T00:00:00.000+00:00")
> minuend = moment.utc(1515704400000)
moment.utc("2018-01-11T21:00:00.000+00:00")
> minuend.add({months: 11, days: 30, hours: 3})
moment.utc("2019-01-11T00:00:00.000+00:00")
```

However, `Duration.diff` returns -1 day instead

```
↓ Duration.diff on directly created dates
✗ 2019-01-11 — 2018-01-11T21:00:00

    { year = 0, month = 11, day = 30, hour = 3, minute = 0, second = 0, millisecond = 0 }
    ╷
    │ Expect.equal
    ╵
    { year = 1, month = 0, day = -1, hour = 3, minute = 0, second = 0, millisecond = 0 }
```