### PR TITLE
Use 12 hrs time with AM/PM in en-US

### DIFF
--- a/src/Date/Extra/Config/Config_en_us.elm
+++ b/src/Date/Extra/Config/Config_en_us.elm
@@ -29,8 +29,8 @@ config =
     , format =
         { date = "%-m/%-d/%Y" -- M/d/YYY
         , longDate = "%A, %B %d, %Y" -- dddd, MMMM dd, yyyy
-        , time = "%-H:%M %p" -- h:mm tt
-        , longTime = "%-H:%M:%S %p" -- h:mm:ss tt
+        , time = "%-I:%M %p" -- h:mm tt
+        , longTime = "%-I:%M:%S %p" -- h:mm:ss tt
         , dateTime = "%-m/%-d/%Y %-I:%M %p" -- date + time
         , firstDayOfWeek = Date.Sun
         }


### PR DESCRIPTION
To make the change easier for you I created this pull request.
Using this patch 12 hrs format is used for en-US locale.