### PR TITLE
Fixed computation of date diff

### DIFF
--- a/src/Date/Extra/Duration.elm
+++ b/src/Date/Extra/Duration.elm
@@ -478,7 +478,7 @@ positiveDiff date1 date2 multiplier =
             propogateCarry minuteDiff minuteCarry 60
 
         ( hourX, dayCarry ) =
-            propogateCarry hourDiff hourCarry 60
+            propogateCarry hourDiff hourCarry 24
 
         -- if dayDiff + dayCarry is negative
         --    then add days in date1 month to make dayDiff positive


### PR DESCRIPTION
Result was wrong if date diff is almost a day:

Date1: <Tue Sep 18 2018 18:00:00 GMT+0300 (EEST)>
Date2: <Mon Sep 17 2018 18:41:37 GMT+0300 (EEST)>
Duration: { year = 0, month = 0, day = 0, hour = 59, minute = 18, second = 22, millisecond = 80 }